### PR TITLE
Composed schema fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Change Log
 
 ## 2.1.0 (TBD)
 
+### Added
+- @Path params are always first in operation.
+
 ### Changed
 - Kotlin updated to [v1.3.71](https://github.com/JetBrains/kotlin/releases/tag/v1.3.71)
 - OpenApi Codegen updated to [v4.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v4.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log
 
 ### Added
 - @Path params are always first in operation.
+- Option to force variables of Composed schema (oneOf and anyOf) as not required (nullable).
 
 ### Changed
 - Kotlin updated to [v1.3.71](https://github.com/JetBrains/kotlin/releases/tag/v1.3.71)
@@ -12,6 +13,9 @@ Change Log
 
 ### Fixed
 - Kotlin allOf inheritance.
+
+### Removed
+- Not used constants.
 
 ## 2.0.1 (2020-03-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Change Log
 - Kotlin updated to [v1.3.71](https://github.com/JetBrains/kotlin/releases/tag/v1.3.71)
 - OpenApi Codegen updated to [v4.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v4.3.0)
 
+### Fixed
+- Kotlin allOf inheritance.
+
 ## 2.0.1 (2020-03-10)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Change Log
 
 ### Changed
 - Kotlin updated to [v1.3.71](https://github.com/JetBrains/kotlin/releases/tag/v1.3.71)
+- OpenApi Codegen updated to [v4.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v4.3.0)
 
 ## 2.0.1 (2020-03-10)
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ configure<SwaggerCodeGenConfig> {
             "apiNameSuffix" to "Service",
             "generateInfrastructure" to false,
             "emptyDataClasses" to false,
-            "generateAliasAsModel" to true,
             "composedArrayAsAny" to true,
+            "generateAliasAsModel" to true,
+            "composedVarsNotRequired" to true,
             "removeMinusTextInHeaderProperty" to true,
             "ignoreEndpointStartingSlash" to true,
             "generatePrimitiveTypeAlias" to false,
@@ -84,6 +85,8 @@ configure<SwaggerCodeGenConfig> {
     - `generateAliasAsModel` - By this property you can generate alias (array, map) as model.
     - `composedArrayAsAny` - By this property array of composed is changed to array of object (kotlin.Any).
     - `generatePrimitiveTypeAlias` - By this property aliases to primitive are also generated.
+    - `composedVarsNotRequired` - By this property Composed schemas (oneOf, anyOf) will have all variables as not required (nullable).
+       Can be used for schema that references object that is required to mark it as not required.
     - `modelNameSuffix` - By this property you can define suffix to all model classes. E.g. `UserDto`, ...
     - `apiNameSuffix` - By this property you can define suffix to all api classes. E.g. `UserService`, ...
     - `apiPackage` - By this property you can define a package name for your service classes

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,7 +5,7 @@ private object Versions {
     const val dokka = "0.10.0"
     const val bintrayGradle = "1.8.4"
 
-    const val openApiCodegen = "4.2.3"
+    const val openApiCodegen = "4.3.0"
 
     const val junit = "4.12"
     const val kotlinTest = "3.3.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx1536m
 
-version=2.0.1
+version=2.1.0-DEV

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx1536m
 
-version=2.1.0-DEV
+version=2.1.0

--- a/lib/src/main/kotlin/cz/eman/swagger/codegen/language/CodegenConst.kt
+++ b/lib/src/main/kotlin/cz/eman/swagger/codegen/language/CodegenConst.kt
@@ -4,19 +4,8 @@ package cz.eman.swagger.codegen.language
  * @author eMan s.r.o. (david.sucharda@eman.cz)
  * @since 2.0.0
  */
-const val DATE_LIBRARY = "dateLibrary"
-const val DATE_LIBRARY_DESCRIPTION = "Option to change Date library to use (default: java8)."
-
-const val REQUEST_DATE_CONVERTER = "requestDateConverter"
-const val REQUEST_DATE_CONVERTER_DESCRIPTION = "JVM-Option. Defines in how to handle date-time objects that are used for a request (as query or parameter)"
-const val REQUEST_DATE_CONVERTER_TO_STRING_DESCRIPTION = "[DEFAULT] Use the 'toString'-method of the date-time object to retrieve the related string representation."
-const val REQUEST_DATE_CONVERTER_TO_JSON_DESCRIPTION = "Date formater option using a json converter."
-
 const val GENERATE_INFRASTRUCTURE_API = "generateInfrastructure"
 const val GENERATE_INFRASTRUCTURE_API_DESCRIPTION = "Option to add infrastructure package"
-
-const val COLLECTION_TYPE = "collectionType"
-const val COLLECTION_TYPE_DESCRIPTION = "Option to change Collection type to use (default: array)."
 
 const val EMPTY_DATA_CLASS = "emptyDataClasses"
 const val EMPTY_DATA_CLASS_DESCRIPTION = "Option to allow empty data classes (default: false)."
@@ -27,6 +16,9 @@ const val COMPOSED_ARRAY_ANY_DESCRIPTION =
 
 const val GENERATE_PRIMITIVE_TYPE_ALIAS = "generatePrimitiveTypeAlias"
 const val GENERATE_PRIMITIVE_TYPE_ALIAS_DESCRIPTION = "Option to generate typealias for primitives."
+
+const val COMPOSED_VARS_NOT_REQUIRED = "composedVarsNotRequired"
+const val COMPOSED_VARS_NOT_REQUIRED_DESCRIPTION = "Option to force variables of ComposedSchema (oneOf, anyOf) to not be required. Default is false."
 
 const val REMOVE_OPERATION_PARAMS = "removeOperationParams"
 const val REMOVE_OPERATION_PARAMS_DESCRIPTION = "Option to remove specific parameters from operation. Uses base name to filter the parameters."


### PR DESCRIPTION
## Changelog:

### Added
- @Path params are always first in operation.
- Option to force variables of Composed schema (oneOf and anyOf) as not required (nullable).

### Changed
- OpenApi Codegen updated to [v4.3.0](https://github.com/OpenAPITools/openapi-generator/releases/tag/v4.3.0)

### Fixed
- Kotlin allOf inheritance.