### PR TITLE
🐛 Fix nested array type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+## 2.1.2 (TBD)
+
+### Fixed
+- Nested arrays and maps in arrays contain type. Array<Array>> is now properly generated as Array<Array<Type>>.
+
 ## 2.1.1 (2020-04-22)
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx1536m
 
-version=2.1.1
+version=2.1.2


### PR DESCRIPTION
Nested arrays and maps in arrays contain type. Array<Array>> is now properly generated as Array<Array<Type>>.

Definitnon:
```
ParamsMap:
  type: object
  additionalProperties:
    type: string
Container:
  type: object
  properties:
    params:
      type: array
      items:
        $ref: '#/components/schemas/ParamsMap'
```
Generated result:
```
@JsonClass(generateAdapter = true)
data class Container (
  @Json(name = "params")
  val params: kotlin.Array<kotlin.collections.Map<kotlin.String, kotlin.String>>? = null
)
```