### PR TITLE
Option to represent Array as ArrayList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Change Log
 
 ### Fixed
 - Data type for type alias pointing to Maps and Arrays.
+- Task additional properties are cleaned properly before each task. Custom properties are removed properly.
 
 ## 2.1.2 (2020-04-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Change Log
 
 ## 2.1.3 (TBD)
 
+### Added:
+- Option to represent Array as ArrayList.
+
 ### Fixed
 - Data type for type alias pointing to Maps and Arrays.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+## 2.1.3 (TBD)
+
+### Fixed
+- Data type for type alias pointing to Maps and Arrays.
+
 ## 2.1.2 (2020-04-28)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ configure<SwaggerCodeGenConfig> {
     - `modelPackage` - By this property you can define a package name for your model classes
     - `removeMinusTextInHeaderProperty` - By this property you can enable to generate name of header property without text minus if it is present.
     - `removeOperationParams` - By this property you can remove specific parameters from API operations.
+    - `arrayAsArrayList` - By this property you can forcefully represent Array as ArrayList which can be useful with complex schemas. Use with caution.
     - `ignoreEndpointStartingSlash` - By this property you can ignore a starting slash from an endpoint definition if it is present
 
 Other options can be found [here](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx1536m
 
-version=2.1.2
+version=2.1.3

--- a/lib/src/main/kotlin/cz/eman/swagger/codegen/SwaggerCodeGenConfig.kt
+++ b/lib/src/main/kotlin/cz/eman/swagger/codegen/SwaggerCodeGenConfig.kt
@@ -27,6 +27,7 @@ open class SwaggerCodeGenConfig : CodegenConfigurator(), Cloneable {
     var configs = listOf<SwaggerCodeGenTaskConfig>()
     var autoHook = true
     private var additionalPropertiesCopy: MutableMap<String, Any> = HashMap()
+    private var additionalPropertiesAddedKeys: MutableSet<String> = mutableSetOf()
 
     override fun toContext(): Context<*> {
         setWorkflowVariables()
@@ -78,7 +79,12 @@ open class SwaggerCodeGenConfig : CodegenConfigurator(), Cloneable {
      * instead of the current one.
      */
     private fun mergeAdditionalProperties() {
+        additionalPropertiesAddedKeys.forEach { additionalPropertiesCopy.remove(it) }
+
         currentTaskConfig.additionalProperties?.forEach { (key, value) ->
+            if (!additionalPropertiesCopy.containsKey(key)) {
+                additionalPropertiesAddedKeys.add(key)
+            }
             additionalPropertiesCopy.remove(key)
             additionalPropertiesCopy[key] = value
         }

--- a/lib/src/main/kotlin/cz/eman/swagger/codegen/language/CodegenConst.kt
+++ b/lib/src/main/kotlin/cz/eman/swagger/codegen/language/CodegenConst.kt
@@ -18,10 +18,16 @@ const val GENERATE_PRIMITIVE_TYPE_ALIAS = "generatePrimitiveTypeAlias"
 const val GENERATE_PRIMITIVE_TYPE_ALIAS_DESCRIPTION = "Option to generate typealias for primitives."
 
 const val COMPOSED_VARS_NOT_REQUIRED = "composedVarsNotRequired"
-const val COMPOSED_VARS_NOT_REQUIRED_DESCRIPTION = "Option to force variables of ComposedSchema (oneOf, anyOf) to not be required. Default is false."
+const val COMPOSED_VARS_NOT_REQUIRED_DESCRIPTION =
+    "Option to force variables of ComposedSchema (oneOf, anyOf) to not be required. Default is false."
 
 const val REMOVE_OPERATION_PARAMS = "removeOperationParams"
-const val REMOVE_OPERATION_PARAMS_DESCRIPTION = "Option to remove specific parameters from operation. Uses base name to filter the parameters."
+const val REMOVE_OPERATION_PARAMS_DESCRIPTION =
+    "Option to remove specific parameters from operation. Uses base name to filter the parameters."
+
+const val ARRAY_AS_ARRAY_LIST = "arrayAsArrayList"
+const val ARRAY_AS_ARRAY_LIST_DESCRIPTION =
+    "Option to represent Array as ArrayList which can be useful with complex schemas. Use with caution."
 
 const val HEADER_CLI = "headerCliOptions"
 const val HEADER_CLI_DESCRIPTION = "Options to generate Header"
@@ -29,4 +35,5 @@ const val REMOVE_MINUS_TEXT_FROM_HEADER = "removeMinusTextInHeaderProperty"
 const val REMOVE_MINUS_TEXT_FROM_HEADER_DESCRIPTION = "Remove minus text from header's property name if it is present."
 
 const val REMOVE_ENDPOINT_STARTING_SLASH = "ignoreEndpointStartingSlash"
-const val REMOVE_ENDPOINT_STARTING_SLASH_DESCRIPTION = "Remove/Ignore a starting slash from an endpoint definition if it is present."
+const val REMOVE_ENDPOINT_STARTING_SLASH_DESCRIPTION =
+    "Remove/Ignore a starting slash from an endpoint definition if it is present."


### PR DESCRIPTION
## Changelog:

### Added:
- Option to represent Array as ArrayList.

### Fixed
- Data type for type alias pointing to Maps and Arrays.
- Task additional properties are cleaned properly before each task. Custom properties are removed properly.

Representing Array as ArrayList helps Moshi convertor to find a proper constructor when array contains complex schema such as Map. Array<Map<>> would not compile propely but ArrayList works fine.