### PR TITLE
✨ Java compilation does not run when compileKotlin is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 Change Log
 ==========
 
+## 2.2.1 (2020-05-10)
+
+### Added:
+- Added option to force java compilation.
+
+### Changed:
+- Does not trigger java tasks when compileKotlin is in the project.
+
 ## 2.2.0 (2020-05-05)
 
 ### Added:
 - Option to represent Array as ArrayList.
 
-### Fixed
+### Fixed:
 - Data type for type alias pointing to Maps and Arrays.
 - Task additional properties are cleaned properly before each task. Custom properties are removed properly.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ configure<SwaggerCodeGenConfig> {
 - `outputPath` - specify output directory
 - `setLibrary` - sets library to generate. Can be either "retrofit2" or "room". Default is "retrofit2".
 - `generatorName` - name or class of supported generator
+- `autoHook` - enables to auto hook generation task to compileKotlin or compileJava (default: true).
+- `forceJava` - forces java compilation when compileKotlin is present (default: false).
 - `configs` - specify input files, output directory and library
 - AdditionalProperties:
     - `templateEngine` - Currently this generator is supporting only `mustache`. Support of `handlebars` is in a progress. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.jvmargs=-Xmx1536m
 
-version=2.2.0
+version=2.2.1

--- a/lib/src/main/kotlin/cz/eman/swagger/codegen/SwaggerCodeGenConfig.kt
+++ b/lib/src/main/kotlin/cz/eman/swagger/codegen/SwaggerCodeGenConfig.kt
@@ -16,6 +16,11 @@ import org.openapitools.codegen.config.Context
  * Input spec path is generated as follows: [sourcePath]/[SwaggerCodeGenTaskConfig.inputFileName].
  * Output dir is generated as follows: [outputPath]/[SwaggerCodeGenTaskConfig.outputFolderName].
  *
+ * Other configuration options:
+ * - [autoHook] enables to auto-hook compilation tasks to compileJava or compileKotlin. When compileKotlin is present
+ *   compileJava part does not run but it can be forced using [forceJava].
+ * - [forceJava] forces java compilation when compileKotlin is present.
+ *
  * @author eMan s.r.o. (info@eman.cz)
  */
 open class SwaggerCodeGenConfig : CodegenConfigurator(), Cloneable {
@@ -26,6 +31,7 @@ open class SwaggerCodeGenConfig : CodegenConfigurator(), Cloneable {
     var outputPath = "./"
     var configs = listOf<SwaggerCodeGenTaskConfig>()
     var autoHook = true
+    var forceJava = false
     private var additionalPropertiesCopy: MutableMap<String, Any> = HashMap()
     private var additionalPropertiesAddedKeys: MutableSet<String> = mutableSetOf()
 


### PR DESCRIPTION
### Changelog

### Added:
- Added option to force java compilation.

### Changed:
- Does not trigger java tasks when compileKotlin is in the project.